### PR TITLE
Show error message if delete fails

### DIFF
--- a/app/controllers/DeploymentsController.scala
+++ b/app/controllers/DeploymentsController.scala
@@ -83,10 +83,10 @@ class DeploymentsController(val authConfig: GoogleAuthConfig, val wsClient: WSCl
   def delete(id: String) = AuthAction { request =>
     implicit val user = request.user
     if (ctx.isAdmin(user)) {
-      if (ES.Deployments.delete(id).run(ctx.jestClient))
-        Ok(s"Deleted $id")
-      else
-        Ok("Failed to delete $id")
+      ES.Deployments.delete(id).run(ctx.jestClient) match {
+        case Left(errorMessage) => Ok(s"Failed to delete $id. Error message: $errorMessage")
+        case Right(_)           => Ok(s"Deleted $id")
+      }
     } else
       Forbidden("Sorry, you're not cool enough")
   }


### PR DESCRIPTION
I just tried to delete a botched deployment. It failed twice, but I don't know why because the error info was being thrown away.

I then made the changes in this PR, then ran it locally and it worked. No idea why, but hopefully I'll have more info to work with next time.