### PR TITLE
Add support for an optional `notifySlackChannel` field

### DIFF
--- a/app/logic/Deployments.scala
+++ b/app/logic/Deployments.scala
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime
 import cats.Id
 import cats.arrow.FunctionK
 import cats.data.Kleisli
+import cats.syntax.option._
 import cats.instances.future._
 import com.gu.googleauth.UserIdentity
 import es.ES
@@ -34,21 +35,23 @@ object Deployments {
                        timestamp: OffsetDateTime,
                        links: Seq[Link],
                        note: Option[String],
-                       result: DeploymentResult): Kleisli[Future, Context, Deployment] = {
+                       result: DeploymentResult,
+                       notifySlackChannel: Option[String]): Kleisli[Future, Context, Deployment] = {
 
     val deployment = Deployment(team, service, jiraComponent, buildId, timestamp, links, note, result)
 
     for {
       jiraResp           <- JIRA.createIssueIfPossible(deployment).local[Context](_.jiraCtx)
-      enrichedDeployment <- enrichWithJiraInfo(deployment, jiraResp).local[Context](_.jiraCtx)
-      _ <- ES.Deployments
-        .create(enrichedDeployment)
-        .local[Context](_.jestClient)
-        .transform(FunctionK.lift[Id, Future](Future.successful))
-      slackResp <- Slack.sendNotification(enrichedDeployment, channel = None).local[Context](_.slackCtx)
-
+      enrichedDeployment <- enrichWithJiraInfo(deployment, jiraResp)
+      _                  <- persistToES(enrichedDeployment)
+      slackResp          <- sendMainSlackNotification(enrichedDeployment)
+      secondSlackResp    <- sendSlackNotificationToCustomChannel(enrichedDeployment, notifySlackChannel)
     } yield {
-      Logger.info(s"Created deployment: $enrichedDeployment. Slack response: $slackResp. JIRA response: $jiraResp")
+      Logger.info(
+        s"""
+           |Created deployment: $enrichedDeployment. First Slack response: $slackResp. Second Slack response: $secondSlackResp. JIRA response: $jiraResp
+         """.stripMargin
+      )
       enrichedDeployment
     }
   }
@@ -62,8 +65,15 @@ object Deployments {
       OffsetDateTime.now(),
       event.links.getOrElse(Nil),
       event.note,
-      event.result.getOrElse(Succeeded)
+      event.result.getOrElse(Succeeded),
+      event.notifySlackChannel
     )
+
+  private def persistToES(deployment: Deployment): Kleisli[Future, Context, Identified[Deployment]] =
+    ES.Deployments
+      .create(deployment)
+      .local[Context](_.jestClient)
+      .transform(FunctionK.lift[Id, Future](Future.successful))
 
   private def enrichWithJiraInfo(deployment: Deployment, jiraResponse: Option[WSResponse]) =
     Kleisli[Future, JIRA.Context, Deployment] { ctx =>
@@ -73,17 +83,21 @@ object Deployments {
           resp.json.as[JsObject].value.get("key") match {
             case None => deployment
             case Some(key) =>
-              Deployment(
-                deployment.team,
-                deployment.service,
-                deployment.jiraComponent,
-                deployment.buildId,
-                deployment.timestamp,
-                deployment.links ++ Seq(Link("Jira Ticket", ctx.browseTicketsUrl + key.as[String])),
-                deployment.note,
-                deployment.result
-              )
+              deployment.copy(links = deployment.links :+ Link("Jira Ticket", ctx.browseTicketsUrl + key.as[String]))
           }
       })
+    }.local[Context](_.jiraCtx)
+
+  private def sendMainSlackNotification(deployment: Deployment): Kleisli[Future, Context, WSResponse] =
+    Slack.sendNotification(deployment, channel = None).local[Context](_.slackCtx)
+
+  private def sendSlackNotificationToCustomChannel(
+      deployment: Deployment,
+      channel: Option[String]): Kleisli[Future, Context, Option[WSResponse]] = {
+    channel match {
+      case Some(ch) => Slack.sendNotification(deployment, channel = Some(ch)).local[Context](_.slackCtx).map(_.some)
+      case None     => Kleisli.pure[Future, Context, Option[WSResponse]](None)
     }
+  }
+
 }

--- a/app/logic/Deployments.scala
+++ b/app/logic/Deployments.scala
@@ -41,11 +41,11 @@ object Deployments {
     for {
       jiraResp           <- JIRA.createIssueIfPossible(deployment).local[Context](_.jiraCtx)
       enrichedDeployment <- enrichWithJiraInfo(deployment, jiraResp).local[Context](_.jiraCtx)
-      identifiedDeployment <- ES.Deployments
+      _ <- ES.Deployments
         .create(enrichedDeployment)
         .local[Context](_.jestClient)
         .transform(FunctionK.lift[Id, Future](Future.successful))
-      slackResp <- Slack.sendNotification(enrichedDeployment).local[Context](_.slackCtx)
+      slackResp <- Slack.sendNotification(enrichedDeployment, channel = None).local[Context](_.slackCtx)
 
     } yield {
       Logger.info(s"Created deployment: $enrichedDeployment. Slack response: $slackResp. JIRA response: $jiraResp")

--- a/app/models/DeploymentKafkaEvent.scala
+++ b/app/models/DeploymentKafkaEvent.scala
@@ -7,5 +7,6 @@ case class DeploymentKafkaEvent(
     buildId: String,
     links: Option[List[Link]],
     note: Option[String],
-    result: Option[DeploymentResult]
+    result: Option[DeploymentResult],
+    notifySlackChannel: Option[String]
 )

--- a/app/slack/Slack.scala
+++ b/app/slack/Slack.scala
@@ -3,7 +3,8 @@ package slack
 import cats.data.Kleisli
 import models.Deployment
 import models.DeploymentResult.{Cancelled, Failed, Succeeded}
-import play.api.Logger
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.Json.{obj, arr}
 import play.api.libs.ws.{WSClient, WSResponse}
 
 import scala.concurrent.Future
@@ -14,22 +15,10 @@ object Slack {
 
   def sendNotification(deployment: Deployment) = Kleisli[Future, Context, WSResponse] { ctx =>
     val json = buildPayload(deployment)
-    ctx.wsClient.url(ctx.webhookUrl).post(Map("payload" -> Seq(json)))
+    ctx.wsClient.url(ctx.webhookUrl).post(Map("payload" -> Seq(Json.stringify(json))))
   }
 
-  private case class Field(title: String, value: String) {
-    override def toString =
-      s"""
-         |{
-         |  "title":"$title",
-         |  "value":"$value",
-         |  "short":true
-         |}
-         |
-       """.stripMargin
-  }
-
-  def buildPayload(deployment: Deployment): String = {
+  def buildPayload(deployment: Deployment): JsValue = {
     val (message, colour) = deployment.result match {
       case Succeeded =>
         (s"Service [${deployment.team}/${deployment.service}] was deployed successfully.", "#00D000")
@@ -38,28 +27,40 @@ object Slack {
       case Cancelled =>
         (s"Deployment of service [${deployment.team}/${deployment.service}] was cancelled.", "#DDDD00")
     }
-    val buildIdField = Field("Build ID", deployment.buildId)
+
+    val fields = buildFields(deployment)
+
+    obj(
+      "attachments" -> arr(
+        obj(
+          "fallback" -> s"$message <https://shipit.ovotech.org.uk/deployments|See recent deployments>",
+          "pretext"  -> s"$message <https://shipit.ovotech.org.uk/deployments|See recent deployments>",
+          "color"    -> colour,
+          "fields"   -> fields
+        )
+      )
+    )
+  }
+
+  private def buildFields(deployment: Deployment) = {
+    def field(title: String, value: String, short: Boolean) = obj(
+      "title" -> title,
+      "value" -> value,
+      "short" -> short
+    )
+
+    val buildIdField = field("Build ID", deployment.buildId, short = true)
+
     val linksField = {
       val value = deployment.links
         .map(link => s"<${link.url}|${link.title}>")
         .mkString(", ")
-      Field("Links", value)
+      field("Links", value, short = true)
     }
-    val notesField
-      : Option[Field] = deployment.note.map(Field("Notes", _)) // TODO build json payload properly to escape newlines etc
-    val fields        = List(Some(buildIdField), Some(linksField), notesField).flatten.mkString(",")
-    s"""
-       |{
-       |  "attachments":[
-       |    {
-       |      "fallback":"$message <https://shipit.ovotech.org.uk/deployments|See recent deployments>",
-       |      "pretext":"$message <https://shipit.ovotech.org.uk/deployments|See recent deployments>",
-       |      "color":"$colour",
-       |      "fields":[$fields]
-       |    }
-       |  ]
-       |}
-     """.stripMargin
+
+    val notesField = deployment.note.map(note => field("Notes", note, short = false))
+
+    List(Some(buildIdField), Some(linksField), notesField).flatten
   }
 
 }

--- a/app/views/guide.scala.html
+++ b/app/views/guide.scala.html
@@ -49,6 +49,16 @@
     -d buildId=123 \
     -d 'jiraComponent=Comms Platform'</pre>
 
+  <p>:shipit: will always send a notification to the #announce_change Slack channel. You can also notify a custom channel if you want to. To do so, include a <code>notifySlackChannel</code> field in your POST.</p>
+
+  <p>For example:</p>
+
+  <pre>$ curl https://shipit.ovotech.org.uk/deployments?apikey=[your-key-here] \
+    -d team=comms \
+    -d service=gateway-event-manager \
+    -d buildId=123 \
+    -d notifySlackChannel=comms-deployments</pre>
+
   <p>Finally, you can also notify :shipit: about failed or cancelled builds:</p>
 
   <pre>$ curl https://shipit.ovotech.org.uk/deployments?apikey=[your-key-here] \
@@ -73,7 +83,7 @@
   "buildId": "123"
 }</pre>
 
-  <p>Just like for the HTTP POST, you can also include an optional list of links, an optional note, a JIRA component name and a deployment result:</p>
+  <p>You can also include all the same optional stuff as you can in the HTTP POST:</p>
 
   <pre>{
   "team": "comms",
@@ -88,7 +98,8 @@
   }],
   "note": "Build started by Chris",
   "jiraComponent": "Comms Platform",
-  "result": "failed"
+  "result": "failed",
+  "notifySlackChannel": "comms-deployments"
 }</pre>
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,9 +1,11 @@
-play.crypto.secret = "super secret"
-play.i18n.langs = [ "en" ]
-play.application.loader = AppLoader
-aws {
-  region = "eu-west-1"
+# This is the config file for running on your local machine.
+# In production the application uses prd.conf.
 
+include "common.conf"
+
+play.crypto.secret = "super secret"
+
+aws {
   es {
     endpointUrl = ${ES_URL}
   }
@@ -11,16 +13,6 @@ aws {
 
 kafka {
   hosts = ${KAFKA_HOSTS}
-  group.id = "shipit"
-
-  topics {
-    deployments = "shipit.deployments"
-  }
-}
-
-akka.kafka.consumer {
-  wakeup-timeout = 5s
-  max-wakeups = 24
 }
 
 slack {
@@ -29,8 +21,6 @@ slack {
 }
 
 jira {
-  browseTicketsUrl = "https://ovotech.atlassian.net/browse/"
-  createIssueApiUrl = "https://ovotech.atlassian.net/rest/api/2/issue",
   username = "dummy"
   username = ${?JIRA_USERNAME}
   password = "dummy"

--- a/conf/common.conf
+++ b/conf/common.conf
@@ -1,0 +1,27 @@
+# This file is for settings that are common across all environments
+
+play.i18n.langs = [ "en" ]
+play.application.loader = AppLoader
+
+aws {
+  region = "eu-west-1"
+}
+
+kafka {
+  group.id = "shipit"
+
+  topics {
+    deployments = "shipit.deployments"
+  }
+}
+
+akka.kafka.consumer {
+  wakeup-timeout = 5s
+  max-wakeups = 24
+}
+
+jira {
+  browseTicketsUrl = "https://ovotech.atlassian.net/browse/"
+  createIssueApiUrl = "https://ovotech.atlassian.net/rest/api/2/issue",
+}
+

--- a/conf/prd.conf
+++ b/conf/prd.conf
@@ -1,10 +1,10 @@
+# This is the config file for the production environment
+
+include "common.conf"
+
 play.crypto.secret = "@@{prd.shipit.applicationSecret}"
-play.i18n.langs = [ "en" ]
-play.application.loader = AppLoader
 
 aws {
-  region = "eu-west-1"
-
   es {
     endpointUrl = "@@{prd.shipit.es.url}"
   }
@@ -12,16 +12,6 @@ aws {
 
 kafka {
   hosts = "@@{prd.kafka_hosts}"
-  group.id = "shipit"
-
-  topics {
-    deployments = "shipit.deployments"
-  }
-}
-
-akka.kafka.consumer {
-  wakeup-timeout = 5s
-  max-wakeups = 24
 }
 
 slack {
@@ -29,8 +19,6 @@ slack {
 }
 
 jira {
-  browseTicketsUrl = "https://ovotech.atlassian.net/browse/"
-  createIssueApiUrl = "https://ovotech.atlassian.net/rest/api/2/issue",
   username = "@@{prd.shipit.jira.username}"
   password = "@@{prd.shipit.jira.password}"
 }

--- a/test/slack/SlackSpec.scala
+++ b/test/slack/SlackSpec.scala
@@ -2,10 +2,10 @@ package slack
 
 import java.time.OffsetDateTime
 
-import io.circe.Json
 import models.{Deployment, DeploymentResult, Link}
 import org.scalatest._
 import io.circe.parser._
+import play.api.libs.json.Json
 
 class SlackSpec extends FlatSpec with Matchers with OptionValues {
 
@@ -24,7 +24,7 @@ class SlackSpec extends FlatSpec with Matchers with OptionValues {
       result = DeploymentResult.Succeeded
     )
     val payload = Slack.buildPayload(deployment)
-    val json    = parse(payload).right.get
+    val json    = parse(Json.stringify(payload)).right.get
 
     val expectedJson = parse(
       """
@@ -48,7 +48,7 @@ class SlackSpec extends FlatSpec with Matchers with OptionValues {
         |       {
         |         "title": "Notes",
         |         "value": "this build was awesome",
-        |         "short": true
+        |         "short": false
         |       }
         |     ]
         |   }

--- a/test/slack/SlackSpec.scala
+++ b/test/slack/SlackSpec.scala
@@ -23,7 +23,7 @@ class SlackSpec extends FlatSpec with Matchers with OptionValues {
       note = Some("this build was awesome"),
       result = DeploymentResult.Succeeded
     )
-    val payload = Slack.buildPayload(deployment)
+    val payload = Slack.buildPayload(deployment, channel = None)
     val json    = parse(Json.stringify(payload)).right.get
 
     val expectedJson = parse(
@@ -49,6 +49,53 @@ class SlackSpec extends FlatSpec with Matchers with OptionValues {
         |         "title": "Notes",
         |         "value": "this build was awesome",
         |         "short": false
+        |       }
+        |     ]
+        |   }
+        | ]
+        |}
+      """.stripMargin
+    ).right.get
+
+    assert(json == expectedJson)
+  }
+
+  it should "build a payload with a custom channel" in {
+    val deployment = Deployment(
+      team = "Team America",
+      service = "my lovely service",
+      jiraComponent = None,
+      buildId = "123",
+      timestamp = OffsetDateTime.now,
+      links = Seq(
+        Link("PR", "https://github.com/pr"),
+        Link("CI", "https://circleci.com/build/123")
+      ),
+      note = None,
+      result = DeploymentResult.Succeeded
+    )
+    val payload = Slack.buildPayload(deployment, channel = Some("my-channel"))
+    val json    = parse(Json.stringify(payload)).right.get
+
+    val expectedJson = parse(
+      """
+        |{
+        | "channel": "my-channel",
+        | "attachments": [
+        |   {
+        |     "fallback": "Service [Team America/my lovely service] was deployed successfully. <https://shipit.ovotech.org.uk/deployments|See recent deployments>",
+        |     "pretext": "Service [Team America/my lovely service] was deployed successfully. <https://shipit.ovotech.org.uk/deployments|See recent deployments>",
+        |     "color": "#00D000",
+        |     "fields": [
+        |       {
+        |         "title": "Build ID",
+        |         "value": "123",
+        |         "short": true
+        |       },
+        |       {
+        |         "title": "Links",
+        |         "value": "<https://github.com/pr|PR>, <https://circleci.com/build/123|CI>",
+        |         "short": true
         |       }
         |     ]
         |   }


### PR DESCRIPTION
The behaviour is to always notify the main channel (announce_change), but also send the same notification to a custom channel if the field is present.