### PR TITLE
Get rid of the concept of deployment result

### DIFF
--- a/app/es/CirceDecoders.scala
+++ b/app/es/CirceDecoders.scala
@@ -3,8 +3,6 @@ package es
 import java.time.OffsetDateTime
 
 import io.circe.Decoder
-import models.DeploymentResult
-import models.DeploymentResult.{Cancelled, Failed, Succeeded}
 
 import scala.util.Try
 
@@ -12,12 +10,5 @@ object CirceDecoders {
 
   implicit val decodeOffsetDateTime: Decoder[OffsetDateTime] =
     Decoder.decodeString.emapTry(x => Try(OffsetDateTime.parse(x)))
-
-  implicit val decodeDeploymentResult: Decoder[DeploymentResult] = Decoder.decodeString.emap {
-    case "Succeeded" | "succeeded" => Right(Succeeded)
-    case "Failed" | "failed"       => Right(Failed)
-    case "Cancelled" | "cancelled" => Right(Cancelled)
-    case other                     => Left(s"Unrecognised deployment result: $other")
-  }
 
 }

--- a/app/es/ES.scala
+++ b/app/es/ES.scala
@@ -44,14 +44,12 @@ object ES {
         teamQuery: Option[String],
         serviceQuery: Option[String],
         buildIdQuery: Option[String],
-        resultQuery: Option[DeploymentResult],
         page: Int
     ) = Reader[JestClient, Page[Identified[Deployment]]] { jest =>
       val filters = Seq(
         teamQuery.map(x => s"""{ "match": { "team": "$x" } }"""),
         serviceQuery.map(x => s"""{ "match": { "service": "$x" } }"""),
-        buildIdQuery.map(x => s"""{ "match": { "buildId": "$x" } }"""),
-        resultQuery.map(x => s"""{ "match": { "result": "$x" } }""")
+        buildIdQuery.map(x => s"""{ "match": { "buildId": "$x" } }""")
       ).flatten
       val query =
         s"""{
@@ -97,8 +95,7 @@ object ES {
         "service"   -> deployment.service,
         "buildId"   -> deployment.buildId,
         "timestamp" -> deployment.timestamp.toString,
-        "links"     -> linksList,
-        "result"    -> deployment.result.toString
+        "links"     -> linksList
       ) ++
         deployment.note.map("note"                   -> _) ++
         deployment.jiraComponent.map("jiraComponent" -> _)
@@ -286,8 +283,7 @@ object ES {
            |            "title": { "type" : "string" },
            |            "url": { "type" : "string" }
            |          }
-           |        },
-           |        "result" : { "type" : "string", "index": "not_analyzed" }
+           |        }
            |      }
            |    }
            |  }

--- a/app/jira/JIRA.scala
+++ b/app/jira/JIRA.scala
@@ -7,7 +7,6 @@ import cats.data.Kleisli
 import cats.instances.future._
 import cats.syntax.option._
 import models.Deployment
-import models.DeploymentResult.{Cancelled, Failed, Succeeded}
 import play.Logger
 import play.api.libs.json.Json.obj
 import play.api.libs.json._
@@ -61,14 +60,7 @@ object JIRA {
   }
 
   def buildPayload(deployment: Deployment, jiraComponent: String, currentTime: OffsetDateTime): JsValue = {
-    val summary = deployment.result match {
-      case Succeeded =>
-        s"Service '${deployment.team}/${deployment.service}' was deployed successfully."
-      case Failed =>
-        s"Deployment of service '${deployment.team}/${deployment.service}' failed."
-      case Cancelled =>
-        s"Deployment of service '${deployment.team}/${deployment.service}' was cancelled."
-    }
+    val summary = s"Service '${deployment.team}/${deployment.service}' was deployed successfully."
     val linksText = {
       if (deployment.links.isEmpty) ""
       else {

--- a/app/logic/Deployments.scala
+++ b/app/logic/Deployments.scala
@@ -12,10 +12,8 @@ import es.ES
 import io.searchbox.client.JestClient
 import jira.JIRA
 import jira.JIRA.CreateIssueKey
-import models.DeploymentResult.Succeeded
 import models._
 import play.api.Logger
-import play.api.libs.json.JsObject
 import play.api.libs.ws.WSResponse
 import slack.Slack
 
@@ -36,10 +34,9 @@ object Deployments {
                        timestamp: OffsetDateTime,
                        links: Seq[Link],
                        note: Option[String],
-                       result: DeploymentResult,
                        notifySlackChannel: Option[String]): Kleisli[Future, Context, Deployment] = {
 
-    val deployment = Deployment(team, service, jiraComponent, buildId, timestamp, links, note, result)
+    val deployment = Deployment(team, service, jiraComponent, buildId, timestamp, links, note)
 
     for {
       jiraResp           <- JIRA.createAndTransitionIssueIfPossible(deployment).local[Context](_.jiraCtx)

--- a/app/models/Deployment.scala
+++ b/app/models/Deployment.scala
@@ -4,24 +4,6 @@ import java.time.OffsetDateTime
 
 case class Link(title: String, url: String)
 
-sealed trait DeploymentResult
-
-object DeploymentResult {
-  case object Succeeded extends DeploymentResult
-  case object Failed    extends DeploymentResult
-  case object Cancelled extends DeploymentResult
-
-  def fromLowerCaseString(string: String) = string match {
-    case "succeeded" => Some(Succeeded)
-    case "failed"    => Some(Failed)
-    case "cancelled" => Some(Cancelled)
-    case _           => None
-  }
-
-  def toLowerCaseString(result: DeploymentResult) = result.toString.toLowerCase
-
-}
-
 case class Deployment(
     team: String,
     service: String,
@@ -29,6 +11,5 @@ case class Deployment(
     buildId: String,
     timestamp: OffsetDateTime,
     links: Seq[Link],
-    note: Option[String],
-    result: DeploymentResult
+    note: Option[String]
 )

--- a/app/slack/Slack.scala
+++ b/app/slack/Slack.scala
@@ -2,7 +2,6 @@ package slack
 
 import cats.data.Kleisli
 import models.Deployment
-import models.DeploymentResult.{Cancelled, Failed, Succeeded}
 import play.api.libs.json.{JsString, JsValue, Json}
 import play.api.libs.json.Json.{arr, obj}
 import play.api.libs.ws.{WSClient, WSResponse}
@@ -19,16 +18,9 @@ object Slack {
   }
 
   def buildPayload(deployment: Deployment, channel: Option[String]): JsValue = {
-    val (message, colour) = deployment.result match {
-      case Succeeded =>
-        (s"Service [${deployment.team}/${deployment.service}] was deployed successfully.", "#00D000")
-      case Failed =>
-        (s"Deployment of service [${deployment.team}/${deployment.service}] failed.", "#D00000")
-      case Cancelled =>
-        (s"Deployment of service [${deployment.team}/${deployment.service}] was cancelled.", "#DDDD00")
-    }
-
-    val fields = buildFields(deployment)
+    val message = s"Service [${deployment.team}/${deployment.service}] was deployed successfully."
+    val colour  = "#00D000"
+    val fields  = buildFields(deployment)
 
     val withoutChannel = obj(
       "attachments" -> arr(

--- a/app/views/ViewHelper.scala
+++ b/app/views/ViewHelper.scala
@@ -1,9 +1,8 @@
 package views
 
-import java.time.{Instant, OffsetDateTime, ZoneId, ZoneOffset}
+import java.time.{OffsetDateTime, ZoneOffset}
 import java.time.format.DateTimeFormatter
 
-import models.DeploymentResult.{Cancelled, Failed, Succeeded}
 import models.{ApiKey, Deployment}
 
 object ViewHelper {
@@ -26,9 +25,4 @@ object ViewHelper {
     else
       <span class="label label-default">Disabled</span>
 
-  def resultBadge(deployment: Deployment) = deployment.result match {
-    case Succeeded => <span class="label label-primary">Succeeded</span>
-    case Failed    => <span class="label label-danger">Failed</span>
-    case Cancelled => <span class="label label-warning">Cancelled</span>
-  }
 }

--- a/app/views/deployments/search.scala.html
+++ b/app/views/deployments/search.scala.html
@@ -43,22 +43,25 @@
 
   <table class="table table-striped">
     <thead>
-      <tr><th>Timestamp</th><th>Team</th><th>Service</th><th>Build ID</th><th>Links</th><th>Notes</th>@if(showAdminColumn){<th>Danger zone</th>}</tr>
+      <tr><th>Timestamp</th><th>Team</th><th>Service</th><th>Build ID</th><th>Links and notes</th>@if(showAdminColumn){<th>Danger zone</th>}</tr>
     </thead>
     <tbody>
       @for(item <- page.items) {
         <tr>
-          <td><time class="timeago" datetime="@item.value.timestamp.toString">@formatDate(item.value.timestamp)</time></td>
+          <td>@formatDate(item.value.timestamp) (<time class="timeago" datetime="@item.value.timestamp.toString">@formatDate(item.value.timestamp)</time>)</td>
           <td>@item.value.team</td>
           <td>@item.value.service</td>
           <td>@item.value.buildId</td>
           <td>
+            <ul>
             @for((link, i) <- item.value.links.zipWithIndex) {
-              <span><a href="@link.url" target="_blank">@link.title</a></span>
-              @if(i < item.value.links.size - 1) { , }
+              <li><a href="@link.url" target="_blank">@link.title</a></li>
+            }
+            </ul>
+            @for(note <- item.value.note) {
+              <pre>@item.value.note</pre>
             }
           </td>
-          <td><pre>@item.value.note</pre></td>
           @if(showAdminColumn) {
             <td>
               <form id="delete_@item.id" method="post" action="@routes.DeploymentsController.delete(item.id)">@CSRF.formField</form>

--- a/app/views/deployments/search.scala.html
+++ b/app/views/deployments/search.scala.html
@@ -1,7 +1,6 @@
-@(page: es.ES.Page[Identified[Deployment]], team: Option[String], service: Option[String], buildId: Option[String], result: Option[DeploymentResult], showAdminColumn: Boolean)(implicit user: com.gu.googleauth.UserIdentity, request: RequestHeader)
+@(page: es.ES.Page[Identified[Deployment]], team: Option[String], service: Option[String], buildId: Option[String], showAdminColumn: Boolean)(implicit user: com.gu.googleauth.UserIdentity, request: RequestHeader)
 
 @import views.ViewHelper._
-@import models.DeploymentResult._
 @import helper._
 
 @main {
@@ -13,7 +12,7 @@
   <div class="panel panel-default">
     <div class="panel-heading">Filters <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#filters" aria-expanded="false" aria-controls="filters">Toggle</button></div>
     <div class="panel-body collapse" id="filters">
-      <form method="get" action="@routes.DeploymentsController.search(None, None, None, None)" class="form form-horizontal">
+      <form method="get" action="@routes.DeploymentsController.search(None, None, None)" class="form form-horizontal">
         <div class="form-group">
           <label class="col-sm-2 control-label" for="team">Team</label>
           <div class="col-sm-4">
@@ -32,17 +31,6 @@
             <input type="text" class="form-control" id="buildId" name="buildId" value="@buildId">
           </div>
         </div>
-        <div class="form-group">
-          <label class="col-sm-2 control-label" for="result">Result</label>
-          <div class="col-sm-4">
-            <select class="form-control" id="result" name="result">
-              <option value="">(any)</option>
-              <option value="@DeploymentResult.toLowerCaseString(Succeeded)" @if(result.contains(DeploymentResult.Succeeded)) { selected="" }>Succeeded</option>
-              <option value="@DeploymentResult.toLowerCaseString(Failed)"    @if(result.contains(DeploymentResult.Failed)) { selected="" }>Failed</option>
-              <option value="@DeploymentResult.toLowerCaseString(Cancelled)" @if(result.contains(DeploymentResult.Cancelled)) { selected="" }>Cancelled</option>
-            </select>
-          </div>
-        </div>
         <!-- TODO date picker -->
         <div class="form-group">
           <div class="col-sm-offset-2 col-sm-4">
@@ -55,7 +43,7 @@
 
   <table class="table table-striped">
     <thead>
-      <tr><th>Timestamp</th><th>Team</th><th>Service</th><th>Build ID</th><th>Result</th><th>Links</th><th>Notes</th>@if(showAdminColumn){<th>Danger zone</th>}</tr>
+      <tr><th>Timestamp</th><th>Team</th><th>Service</th><th>Build ID</th><th>Links</th><th>Notes</th>@if(showAdminColumn){<th>Danger zone</th>}</tr>
     </thead>
     <tbody>
       @for(item <- page.items) {
@@ -64,7 +52,6 @@
           <td>@item.value.team</td>
           <td>@item.value.service</td>
           <td>@item.value.buildId</td>
-          <td>@resultBadge(item.value)</td>
           <td>
             @for((link, i) <- item.value.links.zipWithIndex) {
               <span><a href="@link.url" target="_blank">@link.title</a></span>
@@ -85,12 +72,12 @@
 
   <ul class="pager">
     @if(page.pageNumber > 1) {
-      <li><a href="@routes.DeploymentsController.search(team, service, buildId, result.map(DeploymentResult.toLowerCaseString))">Latest</a></li>
-      <li><a href="@routes.DeploymentsController.search(team, service, buildId, result.map(DeploymentResult.toLowerCaseString), page.pageNumber - 1)">&larr; Newer</a></li>
+      <li><a href="@routes.DeploymentsController.search(team, service, buildId)">Latest</a></li>
+      <li><a href="@routes.DeploymentsController.search(team, service, buildId, page.pageNumber - 1)">&larr; Newer</a></li>
     }
     @if(page.pageNumber < page.lastPage) {
-      <li><a href="@routes.DeploymentsController.search(team, service, buildId, result.map(DeploymentResult.toLowerCaseString), page.pageNumber + 1)">Older &rarr;</a></li>
-      <li><a href="@routes.DeploymentsController.search(team, service, buildId, result.map(DeploymentResult.toLowerCaseString), page.lastPage)">Oldest</a></li>
+      <li><a href="@routes.DeploymentsController.search(team, service, buildId, page.pageNumber + 1)">Older &rarr;</a></li>
+      <li><a href="@routes.DeploymentsController.search(team, service, buildId, page.lastPage)">Oldest</a></li>
     }
   </ul>
 

--- a/app/views/guide.scala.html
+++ b/app/views/guide.scala.html
@@ -59,14 +59,6 @@
     -d buildId=123 \
     -d notifySlackChannel=comms-deployments</pre>
 
-  <p>Finally, you can also notify :shipit: about failed or cancelled builds:</p>
-
-  <pre>$ curl https://shipit.ovotech.org.uk/deployments?apikey=[your-key-here] \
-    -d team=comms \
-    -d service=gateway-event-manager \
-    -d buildId=123 \
-    -d result=failed</pre>
-
   <p>For a real-world example, take a look at <a href="https://github.com/ovotech/comms-ci-scripts/blob/master/notify_shipit.sh" target="_blank">the script the comms team use in CircleCI</a>.</p>
 
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -22,7 +22,7 @@
 
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="@routes.DeploymentsController.search(None, None, None, None)">Search</a></li>
+            <li><a href="@routes.DeploymentsController.search(None, None, None)">Search</a></li>
             <li><a href="@routes.ApiKeysController.list()">API keys</a></li>
             <li><a href="@routes.MainController.guide()">User Guide</a></li>
           </ul>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -25,6 +25,7 @@
             <li><a href="@routes.DeploymentsController.search(None, None, None)">Search</a></li>
             <li><a href="@routes.ApiKeysController.list()">API keys</a></li>
             <li><a href="@routes.MainController.guide()">User Guide</a></li>
+            <li><a href="https://github.com/ovotech/shipit">GitHub</a></li>
           </ul>
 
           <p class="navbar-text navbar-right">Logged in as @user.fullName</p>

--- a/conf/routes
+++ b/conf/routes
@@ -6,7 +6,7 @@ GET     /                           controllers.MainController.index
 GET     /guide                      controllers.MainController.guide
 GET     /healthcheck                controllers.MainController.healthcheck
 
-GET     /deployments                controllers.DeploymentsController.search(team: Option[String], service: Option[String], buildId: Option[String], result: Option[String], page: Int ?= 1)
+GET     /deployments                controllers.DeploymentsController.search(team: Option[String], service: Option[String], buildId: Option[String], page: Int ?= 1)
 POST    /deployments                controllers.DeploymentsController.create
 POST    /deployments/:id/delete     controllers.DeploymentsController.delete(id)
 

--- a/test/jira/JIRASpec.scala
+++ b/test/jira/JIRASpec.scala
@@ -3,7 +3,7 @@ package jira
 import java.time.{Clock, Instant, OffsetDateTime, ZoneId}
 
 import io.circe.parser._
-import models.{Deployment, DeploymentResult, Link}
+import models.{Deployment, Link}
 import org.scalatest._
 import play.api.libs.json.Json
 
@@ -20,8 +20,7 @@ class JIRASpec extends FlatSpec with Matchers with OptionValues {
         Link("PR", "https://github.com/pr"),
         Link("CI", "https://circleci.com/build/123")
       ),
-      note = Some("this build was awesome"),
-      result = DeploymentResult.Succeeded
+      note = Some("this build was awesome")
     )
     val payload =
       JIRA.buildPayload(deployment,

--- a/test/slack/SlackSpec.scala
+++ b/test/slack/SlackSpec.scala
@@ -2,7 +2,7 @@ package slack
 
 import java.time.OffsetDateTime
 
-import models.{Deployment, DeploymentResult, Link}
+import models.{Deployment, Link}
 import org.scalatest._
 import io.circe.parser._
 import play.api.libs.json.Json
@@ -20,8 +20,7 @@ class SlackSpec extends FlatSpec with Matchers with OptionValues {
         Link("PR", "https://github.com/pr"),
         Link("CI", "https://circleci.com/build/123")
       ),
-      note = Some("this build was awesome"),
-      result = DeploymentResult.Succeeded
+      note = Some("this build was awesome")
     )
     val payload = Slack.buildPayload(deployment, channel = None)
     val json    = parse(Json.stringify(payload)).right.get
@@ -71,8 +70,7 @@ class SlackSpec extends FlatSpec with Matchers with OptionValues {
         Link("PR", "https://github.com/pr"),
         Link("CI", "https://circleci.com/build/123")
       ),
-      note = None,
-      result = DeploymentResult.Succeeded
+      note = None
     )
     val payload = Slack.buildPayload(deployment, channel = Some("my-channel"))
     val json    = parse(Json.stringify(payload)).right.get


### PR DESCRIPTION
From now on we assume that people will only notify shipit about successful deployments. (This is how people have been using it in practice so far.)

This simplifies the code and allows us to remove a pointless column from the UI.

Fixes #29 