### PR TITLE
Migrate to a new index

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -6,6 +6,7 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.google.common.base.Supplier
 import controllers._
 import com.gu.googleauth.{AntiForgeryChecker, AuthAction, GoogleAuthConfig, UserIdentity}
+import com.gu.play.secretrotation.DualSecretTransition.InitialSecret
 import datadog.Datadog
 import io.searchbox.client.{JestClient, JestClientFactory}
 import io.searchbox.client.config.HttpClientConfig
@@ -40,7 +41,10 @@ class AppComponents(context: Context, config: Config)
     clientSecret = config.google.clientSecret.value,
     redirectUrl = config.google.redirectUrl,
     domain = "ovoenergy.com",
-    antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration)
+    antiForgeryChecker = AntiForgeryChecker(
+      InitialSecret(httpConfiguration.secret),
+      AntiForgeryChecker.signatureAlgorithmFromPlay(httpConfiguration)
+    )
   )
 
   val jestClient: JestClient = {

--- a/app/controllers/DeploymentsController.scala
+++ b/app/controllers/DeploymentsController.scala
@@ -12,7 +12,6 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class DeploymentsController(controllerComponents: ControllerComponents,
                             authAction: AuthAction[AnyContent],

--- a/app/models/Service.scala
+++ b/app/models/Service.scala
@@ -1,0 +1,9 @@
+package models
+
+import java.time.OffsetDateTime
+
+case class Service(
+    team: String,
+    service: String,
+    lastDeployed: OffsetDateTime
+)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 organization := "com.ovoenergy"
-scalaVersion := "2.11.11" // TODO Scala 2.12
+scalaVersion := "2.12.6"
 scalacOptions += "-Ypartial-unification"
 
 // The version number is fixed, for the sake of simpler deployment scripts.
@@ -7,27 +7,26 @@ scalacOptions += "-Ypartial-unification"
 version := "1.0"
 
 resolvers += Resolver.bintrayRepo("ovotech", "maven")
-// TODO bump various libs
-val circeVersion = "0.9.0"
+val circeVersion = "0.9.3"
 val cirisVersion = "0.10.2"
 libraryDependencies ++= Seq(
   ws,
   filters,
   "io.circe"                   %% "circe-parser"                   % circeVersion,
   "io.circe"                   %% "circe-generic"                  % circeVersion,
-  "com.typesafe.akka"          %% "akka-slf4j"                     % "2.4.16",
-  "org.typelevel"              %% "cats-core"                      % "1.2.0",
-  "com.gu"                     %% "play-googleauth"                % "0.7.2",
-  "io.searchbox"               % "jest"                            % "5.3.3",
-  "vc.inreach.aws"             % "aws-signing-request-interceptor" % "0.0.15",
-  "com.amazonaws"              % "aws-java-sdk-core"               % "1.11.261",
+  "com.typesafe.akka"          %% "akka-slf4j"                     % "2.5.16",
+  "org.typelevel"              %% "cats-core"                      % "1.3.1",
+  "com.gu"                     %% "play-googleauth"                % "0.7.7",
+  "io.searchbox"               % "jest"                            % "6.3.1",
+  "vc.inreach.aws"             % "aws-signing-request-interceptor" % "0.0.21",
+  "com.amazonaws"              % "aws-java-sdk-core"               % "1.11.404",
   "me.moocar"                  % "logback-gelf"                    % "0.2",
   "is.cir"                     %% "ciris-core"                     % cirisVersion,
   "is.cir"                     %% "ciris-cats"                     % cirisVersion,
   "com.ovoenergy"              %% "ciris-aws-ssm"                  % "0.6",
-  "org.scalatest"              %% "scalatest"                      % "3.0.4" % Test,
-  "com.github.alexarchambault" %% "scalacheck-shapeless_1.13"      % "1.1.8" % Test,
-  "org.scalacheck"             %% "scalacheck"                     % "1.13.5" % Test
+  "org.scalatest"              %% "scalatest"                      % "3.0.5" % Test,
+  "com.github.alexarchambault" %% "scalacheck-shapeless_1.14"      % "1.2.0" % Test,
+  "org.scalacheck"             %% "scalacheck"                     % "1.14.0" % Test
 )
 
 enablePlugins(PlayScala, DockerPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"   % "2.6.10")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"   % "2.6.18")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")


### PR DESCRIPTION
`string` data type has been deprecated and replaced with `text` and `keyword` types.

We need fields to be `keyword` type if we want to use them in aggregations.

I've created a new index `shipit_v2` and used the Reindex API to migrate the data to it.