### PR TITLE
Implement a service directory

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -98,12 +98,15 @@ class AppComponents(context: Context, config: Config)
     new ApiKeysController(controllerComponents, authAction, googleAuthConfig, wsClient, jestClient)
   val deploymentsController =
     new DeploymentsController(controllerComponents, authAction, apiKeyAuth, googleAuthConfig, wsClient, deploymentsCtx)
+  val servicesController =
+    new ServicesController(controllerComponents, authAction, googleAuthConfig, wsClient, jestClient)
   val authController = new AuthController(controllerComponents, googleAuthConfig, wsClient)
 
   lazy val router: Router = new Routes(
     httpErrorHandler,
     mainController,
     deploymentsController,
+    servicesController,
     apiKeysController,
     authController,
     assets

--- a/app/controllers/ServicesController.scala
+++ b/app/controllers/ServicesController.scala
@@ -1,0 +1,24 @@
+package controllers
+
+import com.gu.googleauth.{AuthAction, GoogleAuthConfig, UserIdentity}
+import es.ES
+import io.searchbox.client.JestClient
+import play.api.libs.ws.WSClient
+import play.api.mvc._
+
+import scala.concurrent.ExecutionContext
+
+class ServicesController(controllerComponents: ControllerComponents,
+                         authAction: AuthAction[AnyContent],
+                         val authConfig: GoogleAuthConfig,
+                         val wsClient: WSClient,
+                         jestClient: JestClient)(implicit val ec: ExecutionContext)
+    extends AbstractController(controllerComponents) {
+
+  def list(days: Int) = authAction { request =>
+    implicit val user: UserIdentity = request.user
+    val services                    = ES.Deployments.listServices(deployedInLastNDays = days).run(jestClient)
+    Ok(views.html.services.list(services, days))
+  }
+
+}

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -23,6 +23,7 @@
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
             <li><a href="@routes.DeploymentsController.search(None, None, None)">Search</a></li>
+            <li><a href="@routes.ServicesController.list()">Services</a></li>
             <li><a href="@routes.ApiKeysController.list()">API keys</a></li>
             <li><a href="@routes.MainController.guide()">User Guide</a></li>
             <li><a href="https://github.com/ovotech/shipit">GitHub</a></li>

--- a/app/views/services/list.scala.html
+++ b/app/views/services/list.scala.html
@@ -1,0 +1,38 @@
+@(services: Seq[Service], days: Int)(implicit user: com.gu.googleauth.UserIdentity)
+
+@import views.ViewHelper._
+
+@main {
+
+  <div class="page-header">
+    <h1>Services</h1>
+  </div>
+
+  <form method="get" action="@routes.ServicesController.list(0)" class="form form-horizontal">
+    <div class="form-group">
+      <label class="col-sm-4 control-label" for="team">Show services deployed in the last N days</label>
+      <div class="col-sm-2">
+        <input type="text" class="form-control" id="days" name="days" value="@days">
+      </div>
+      <div class="col-sm-4">
+        <button type="submit" class="btn btn-primary">Filter</button>
+      </div>
+    </div>
+  </form>
+
+  <table class="table table-striped">
+    <thead>
+      <tr><th>Team</th><th>Service</th><th>Last deployment</th></tr>
+    </thead>
+    <tbody>
+      @for(item <- services) {
+        <tr>
+          <td>@item.team</td>
+          <td>@item.service</td>
+          <td>@formatDate(item.lastDeployed) (<time class="timeago" datetime="@item.lastDeployed.toString">@formatDate(item.lastDeployed)</time>)</td>
+        </tr>
+      }
+    </tbody>
+  </table>
+
+}

--- a/conf/routes
+++ b/conf/routes
@@ -10,6 +10,8 @@ GET     /deployments                controllers.DeploymentsController.search(tea
 POST    /deployments                controllers.DeploymentsController.create
 POST    /deployments/:id/delete     controllers.DeploymentsController.delete(id)
 
+GET     /services                   controllers.ServicesController.list(days: Int ?= 99999)
+
 GET     /api-keys                   controllers.ApiKeysController.list(page: Int ?= 1)
 POST    /api-keys                   controllers.ApiKeysController.create
 POST    /api-keys/:id/disable       controllers.ApiKeysController.disable(id)


### PR DESCRIPTION
Uses an ES aggregation to retrieve a distinct list of services, along
with their latest deployment time, then vomits this information into a
table.

Supports simple filtering in case you're only interested in recently
deployed services.