### PR TITLE
Couple of changes related to API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@
 
 ## How to run locally
 
-Export all necessary environment variables (see `conf/application.conf`). Then `sbt run`.
+You'll need access to the `eng-services` AWS account.
+
+Set `AWS_PROFILE` to point at that account, and run `sbt run`.
+
+e.g. `AWS_PROFILE=eng-services sbt run`.
+
+The app will load all necessary configuration from the AWS parameter store.
 
 ## Documentation
 

--- a/app/controllers/ApiKeyAuth.scala
+++ b/app/controllers/ApiKeyAuth.scala
@@ -17,7 +17,8 @@ class ApiKeyAuth(jestClient: JestClient, actionBuilder: DefaultActionBuilder)(im
         case Some(key) =>
           ES.ApiKeys.findByKey(key).run(jestClient) match {
             case Some(apiKey) if apiKey.active =>
-              // OK, allow request to proceed
+              // OK, update last-used timestamp for API key and allow request to proceed
+              ES.ApiKeys.updateLastUsed(key).run(jestClient)
               None
             case _ =>
               Some(Unauthorized("Invalid API key"))

--- a/app/controllers/ApiKeysController.scala
+++ b/app/controllers/ApiKeysController.scala
@@ -20,8 +20,8 @@ class ApiKeysController(controllerComponents: ControllerComponents,
 
   def list(page: Int) = authAction { implicit request =>
     implicit val user: UserIdentity = request.user
-    val items                       = ES.ApiKeys.list(request.user.email, page).run(jestClient)
-    Ok(views.html.apikeys.list(items))
+    val keys                        = ES.ApiKeys.list(page).run(jestClient)
+    Ok(views.html.apikeys.list(keys))
   }
 
   def create = authAction { implicit request =>

--- a/app/models/ApiKey.scala
+++ b/app/models/ApiKey.scala
@@ -8,5 +8,6 @@ case class ApiKey(
     description: Option[String],
     createdAt: OffsetDateTime,
     createdBy: String,
-    active: Boolean
+    active: Boolean,
+    lastUsed: Option[OffsetDateTime]
 )

--- a/app/views/ViewHelper.scala
+++ b/app/views/ViewHelper.scala
@@ -3,7 +3,7 @@ package views
 import java.time.{OffsetDateTime, ZoneOffset}
 import java.time.format.DateTimeFormatter
 
-import models.{ApiKey, Deployment}
+import models.ApiKey
 
 object ViewHelper {
 
@@ -11,13 +11,6 @@ object ViewHelper {
     offsetDateTime
       .atZoneSameInstant(ZoneOffset.UTC)
       .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")) + " GMT"
-
-  def formatOptDate(opt: Option[OffsetDateTime]): String =
-    opt.map(formatDate).getOrElse("(unknown)")
-
-  def dateToLong(offsetDateTime: OffsetDateTime): Long = {
-    offsetDateTime.toInstant.toEpochMilli
-  }
 
   def statusBadge(apiKey: ApiKey) =
     if (apiKey.active)

--- a/app/views/apikeys/list.scala.html
+++ b/app/views/apikeys/list.scala.html
@@ -1,4 +1,4 @@
-@(items: Seq[ApiKey])(implicit user: com.gu.googleauth.UserIdentity, request: RequestHeader, flash: Flash)
+@(page: es.ES.Page[ApiKey])(implicit user: com.gu.googleauth.UserIdentity, request: RequestHeader, flash: Flash)
 
 @import views.ViewHelper._
 @import helper._
@@ -11,6 +11,7 @@
 
   <p>You will need an API key if you want to send deployment events to :shipit:</p>
 
+
   @for(info <- flash.get("info")) {
     <div class="alert alert-info" role="alert">@info</div>
   }
@@ -18,15 +19,17 @@
     <div class="alert alert-danger" role="alert">@error</div>
   }
 
+  <p>Here are the API keys that currently exist, sorted by the user who created them.</p>
+
   <table class="table table-striped">
     <thead>
-      <tr><th>Key</th><th>Created</th><th>Status</th><th>Description</th><th>Actions</th></tr>
+      <tr><th>Key</th><th>Created by</th><th>Status</th><th>Description</th><th>Actions</th></tr>
     </thead>
     <tbody>
-      @for(item <- items) {
+      @for(item <- page.items) {
         <tr>
           <td>@item.key</td>
-          <td>@formatDate(item.createdAt) by @item.createdBy</td>
+          <td>@item.createdBy</td>
           <td>@statusBadge(item)</td>
           <td>@item.description</td>
           <td>
@@ -44,6 +47,15 @@
       }
     </tbody>
   </table>
+
+  <ul class="pager">
+    @if(page.pageNumber > 1) {
+      <li><a href="@routes.ApiKeysController.list(page.pageNumber - 1)">&larr; Prev</a></li>
+    }
+    @if(page.pageNumber < page.lastPage) {
+      <li><a href="@routes.ApiKeysController.list(page.pageNumber + 1)">Next &rarr;</a></li>
+    }
+  </ul>
 
   <div class="panel panel-default">
     <div class="panel-heading">Create an API key</div>

--- a/app/views/apikeys/list.scala.html
+++ b/app/views/apikeys/list.scala.html
@@ -1,3 +1,4 @@
+@import java.time.OffsetDateTime
 @(page: es.ES.Page[ApiKey])(implicit user: com.gu.googleauth.UserIdentity, request: RequestHeader, flash: Flash)
 
 @import views.ViewHelper._
@@ -23,7 +24,7 @@
 
   <table class="table table-striped">
     <thead>
-      <tr><th>Key</th><th>Created by</th><th>Status</th><th>Description</th><th>Actions</th></tr>
+      <tr><th>Key</th><th>Created by</th><th>Status</th><th>Last used</th><th>Description</th><th>Actions</th></tr>
     </thead>
     <tbody>
       @for(item <- page.items) {
@@ -31,6 +32,7 @@
           <td>@item.key</td>
           <td>@item.createdBy</td>
           <td>@statusBadge(item)</td>
+          <td>@item.lastUsed.fold[Html](Html("(unknown)")){timestamp: OffsetDateTime => <time class="timeago" datetime="@timestamp.toString">@formatDate(timestamp)</time>}</td>
           <td>@item.description</td>
           <td>
             <form id="disable_@item.id" method="post" action="@routes.ApiKeysController.disable(item.id)">@CSRF.formField</form>

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 organization := "com.ovoenergy"
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 scalacOptions += "-Ypartial-unification"
 
 // The version number is fixed, for the sake of simpler deployment scripts.
@@ -7,7 +7,7 @@ scalacOptions += "-Ypartial-unification"
 version := "1.0"
 
 resolvers += Resolver.bintrayRepo("ovotech", "maven")
-val circeVersion = "0.9.3"
+val circeVersion = "0.10.1"
 val cirisVersion = "0.10.2"
 libraryDependencies ++= Seq(
   ws,
@@ -15,11 +15,11 @@ libraryDependencies ++= Seq(
   "io.circe"                   %% "circe-parser"                   % circeVersion,
   "io.circe"                   %% "circe-generic"                  % circeVersion,
   "com.typesafe.akka"          %% "akka-slf4j"                     % "2.5.16",
-  "org.typelevel"              %% "cats-core"                      % "1.3.1",
+  "org.typelevel"              %% "cats-core"                      % "1.4.0",
   "com.gu"                     %% "play-googleauth"                % "0.7.7",
   "io.searchbox"               % "jest"                            % "6.3.1",
   "vc.inreach.aws"             % "aws-signing-request-interceptor" % "0.0.21",
-  "com.amazonaws"              % "aws-java-sdk-core"               % "1.11.404",
+  "com.amazonaws"              % "aws-java-sdk-core"               % "1.11.441",
   "me.moocar"                  % "logback-gelf"                    % "0.2",
   "is.cir"                     %% "ciris-core"                     % cirisVersion,
   "is.cir"                     %% "ciris-cats"                     % cirisVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"   % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"   % "2.6.20")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")


### PR DESCRIPTION
The API keys page now shows all keys, not only those created by the logged-in user.

This is so that keys don't become invisible when their creator leaves the company. An API key's natural assocation is with a team or a service, not with an individual user.

Also added a last-used timestamp to API keys, to make it easy to find keys that can be deleted.