### PR TITLE
Allow "@kaluza.com" to login

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -35,11 +35,10 @@ class AppComponents(context: Context, config: Config)
   override def configuration: Configuration =
     context.initialConfiguration ++ Configuration("play.http.secret.key" -> config.play.secretKey.value)
 
-  val googleAuthConfig = GoogleAuthConfig(
+  val googleAuthConfig = GoogleAuthConfig.withNoDomainRestriction(
     clientId = config.google.clientId,
     clientSecret = config.google.clientSecret.value,
     redirectUrl = config.google.redirectUrl,
-    domain = "ovoenergy.com",
     antiForgeryChecker = AntiForgeryChecker(
       InitialSecret(httpConfiguration.secret.secret),
       AntiForgeryChecker.signatureAlgorithmFromPlay(httpConfiguration)

--- a/app/Config.scala
+++ b/app/Config.scala
@@ -83,8 +83,7 @@ object AdminConfig {
     ConfigValue.default(
       AdminConfig(
         adminEmailAddresses = List(
-          "andy.summers@ovoenergy.com",
-          "rui.morais@ovoenergy.com",
+          "rui.morais@kaluza.com",
           "tom.verran@ovoenergy.com"
         )
       )


### PR DESCRIPTION
With the recent change of Orion emails to '@kaluza.com', people without a '@ovoenergy.com' account cannot login to shipit.
This PR removes the domain restriction given that only one domain can be specified. This shouldn't be an issue given that the service is only available inside the private network.