### PR TITLE
Use a temporary fork of play-googleauth to allow Kaluza access

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -39,7 +39,7 @@ class AppComponents(context: Context, config: Config)
     clientId = config.google.clientId,
     clientSecret = config.google.clientSecret.value,
     redirectUrl = config.google.redirectUrl,
-    domain = "ovoenergy.com",
+    domains = List("ovoenergy.com", "kaluza.com"),
     antiForgeryChecker = AntiForgeryChecker(
       InitialSecret(httpConfiguration.secret.secret),
       AntiForgeryChecker.signatureAlgorithmFromPlay(httpConfiguration)

--- a/build.sbt
+++ b/build.sbt
@@ -12,20 +12,20 @@ val cirisVersion = "1.0.4"
 libraryDependencies ++= Seq(
   ws,
   filters,
-  "io.circe"                   %% "circe-parser"                   % circeVersion,
-  "io.circe"                   %% "circe-generic"                  % circeVersion,
-  "com.typesafe.akka"          %% "akka-slf4j"                     % "2.5.26",
-  "org.typelevel"              %% "cats-core"                      % "2.1.0",
-  "com.gu.play-googleauth"     %% "play-v27"                       % "1.0.3",
-  "io.searchbox"               % "jest"                            % "6.3.1",
-  "vc.inreach.aws"             % "aws-signing-request-interceptor" % "0.0.22",
-  "com.amazonaws"              % "aws-java-sdk-core"               % "1.11.657",
-  "me.moocar"                  % "logback-gelf"                    % "0.2",
-  "is.cir"                     %% "ciris"                          % cirisVersion,
-  "com.ovoenergy"              %% "ciris-aws-ssm"                  % "1.0.0",
-  "org.scalatest"              %% "scalatest"                      % "3.1.0" % Test,
-  "com.github.alexarchambault" %% "scalacheck-shapeless_1.14"      % "1.2.3" % Test,
-  "org.scalacheck"             %% "scalacheck"                     % "1.14.2" % Test
+  "io.circe"                      %% "circe-parser"                   % circeVersion,
+  "io.circe"                      %% "circe-generic"                  % circeVersion,
+  "com.typesafe.akka"             %% "akka-slf4j"                     % "2.5.26",
+  "org.typelevel"                 %% "cats-core"                      % "2.1.0",
+  "com.ovoenergy.play-googleauth" %% "play-v27"                       % "1.0.6",
+  "io.searchbox"                  % "jest"                            % "6.3.1",
+  "vc.inreach.aws"                % "aws-signing-request-interceptor" % "0.0.22",
+  "com.amazonaws"                 % "aws-java-sdk-core"               % "1.11.657",
+  "me.moocar"                     % "logback-gelf"                    % "0.2",
+  "is.cir"                        %% "ciris"                          % cirisVersion,
+  "com.ovoenergy"                 %% "ciris-aws-ssm"                  % "1.0.0",
+  "org.scalatest"                 %% "scalatest"                      % "3.1.0" % Test,
+  "com.github.alexarchambault"    %% "scalacheck-shapeless_1.14"      % "1.2.3" % Test,
+  "org.scalacheck"                %% "scalacheck"                     % "1.14.2" % Test
 )
 
 enablePlugins(PlayScala, DockerPlugin)


### PR DESCRIPTION
I'm waiting for my PR to play-googleauth to be approved (and feel a bit guilty chasing people before next week) but in the meantime I've published the library to our Bintray so we can go ahead and provide access to Kaluza for now.

You can see the library changes here: https://github.com/guardian/play-googleauth/pull/76