### PR TITLE
Move back to The Guardian's play-googleauth

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "io.circe"                      %% "circe-generic"                  % circeVersion,
   "com.typesafe.akka"             %% "akka-slf4j"                     % "2.5.26",
   "org.typelevel"                 %% "cats-core"                      % "2.1.0",
-  "com.ovoenergy.play-googleauth" %% "play-v27"                       % "1.0.6",
+  "com.gu.play-googleauth"        %% "play-v27"                       % "1.0.6",
   "io.searchbox"                  % "jest"                            % "6.3.1",
   "vc.inreach.aws"                % "aws-signing-request-interceptor" % "0.0.22",
   "com.amazonaws"                 % "aws-java-sdk-core"               % "1.11.657",


### PR DESCRIPTION
Now that https://github.com/guardian/play-googleauth/pull/76 has been merged and `com.gu.play-googleauth` has been released we can go back to that instead of my dubious Bintray fork :tada: 
Thanks @AWare for releasing!
